### PR TITLE
Install RVM

### DIFF
--- a/roles/ubuntu-slaves/tasks/install_libraries.yml
+++ b/roles/ubuntu-slaves/tasks/install_libraries.yml
@@ -107,4 +107,4 @@
   - name: "Installing rvm"
     sudo: yes
     sudo_user: jenkins
-    shell: curl -L https://get.rvm.io | bash -s stable --autolibs=3 creates=~/.rvm
+    shell: curl -L https://get.rvm.io | bash -s stable --autolibs=read-fail creates=~/.rvm


### PR DESCRIPTION
In response to [INFRA-8086](https://issues.apache.org/jira/browse/INFRA-8086), this pull requests aims at installing RVM on the jenkins slaves. Disclaimer: I have never worked with Ansible before and applied a monkey-see-monkey-do-pattern. I also didn't know how to test if it works, so please review the small change before applying the patch. Thanks!
