### PR TITLE
INFRA-8437 - fix umask for jenkins

### DIFF
--- a/roles/common/tasks/setup_user.yml
+++ b/roles/common/tasks/setup_user.yml
@@ -43,3 +43,10 @@
     sudo: yes
     sudo_user: root
     file: src=/home/jenkins dest=/home/hudson state=link owner=jenkins group=jenkins
+
+  - name: setup user | set umask in .profile
+    sudo: yes
+    sudo_user: root
+    lineinfile: dest=/home/jenkins/.profile
+                line="umask 022"
+                state=present


### PR DESCRIPTION
Makes sure we have an uncommented "umask 022" line in /home/jenkins/.profile.
